### PR TITLE
Add startup sleep timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ENV JAVA_OPTS="-Xmx512m"
 COPY --from=sbt-build /app.zip .
 RUN unzip app.zip
 
-RUN chmod u+x bin/kafka-flightstream-streams
+COPY entrypoint.sh ./
+RUN chmod u+x entrypoint.sh bin/kafka-flightstream-streams
 
-ENTRYPOINT ["./bin/kafka-flightstream-streams"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo 'Starting up streams aggregator...' >&2
+
+if [[ $STARTUP_SLEEP_TIMEOUT ]]; then
+  echo "sleeping for $STARTUP_SLEEP_TIMEOUT seconds" >&2
+  sleep $STARTUP_SLEEP_TIMEOUT
+fi
+
+exec ./bin/kafka-flightstream-streams


### PR DESCRIPTION
When running locally with `docker-compose` we need to wait some time in order to setup the topics in Kafka.